### PR TITLE
Adds --web flag to open codespace in vscode web

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -183,6 +183,7 @@ type Codespace struct {
 	VSCSTarget                     string              `json:"vscs_target"`
 	PendingOperation               bool                `json:"pending_operation"`
 	PendingOperationDisabledReason string              `json:"pending_operation_disabled_reason"`
+	WebUrl                         string              `json:"web_url"`
 }
 
 type CodespaceGitStatus struct {

--- a/pkg/cmd/codespace/code.go
+++ b/pkg/cmd/codespace/code.go
@@ -12,6 +12,7 @@ func newCodeCmd(app *App) *cobra.Command {
 	var (
 		codespace   string
 		useInsiders bool
+		useWeb      bool
 	)
 
 	codeCmd := &cobra.Command{
@@ -19,21 +20,30 @@ func newCodeCmd(app *App) *cobra.Command {
 		Short: "Open a codespace in Visual Studio Code",
 		Args:  noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return app.VSCode(cmd.Context(), codespace, useInsiders)
+			return app.VSCode(cmd.Context(), codespace, useInsiders, useWeb)
 		},
 	}
 
 	codeCmd.Flags().StringVarP(&codespace, "codespace", "c", "", "Name of the codespace")
 	codeCmd.Flags().BoolVar(&useInsiders, "insiders", false, "Use the insiders version of Visual Studio Code")
+	codeCmd.Flags().BoolVar(&useWeb, "web", false, "Use the web version of Visual Studio Code")
 
 	return codeCmd
 }
 
 // VSCode opens a codespace in the local VS VSCode application.
-func (a *App) VSCode(ctx context.Context, codespaceName string, useInsiders bool) error {
+func (a *App) VSCode(ctx context.Context, codespaceName string, useInsiders bool, useWeb bool) error {
 	codespace, err := getOrChooseCodespace(ctx, a.apiClient, codespaceName)
 	if err != nil {
 		return err
+	}
+
+	if useWeb {
+		if err := a.browser.Browse(codespace.WebUrl); err != nil {
+			return fmt.Errorf("error opening Codespace: %w", err)
+		}
+
+		return nil
 	}
 
 	url := vscodeProtocolURL(codespace.Name, useInsiders)

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -13,6 +13,7 @@ func TestApp_VSCode(t *testing.T) {
 	type args struct {
 		codespaceName string
 		useInsiders   bool
+		useWeb        bool
 	}
 	tests := []struct {
 		name    string
@@ -38,6 +39,16 @@ func TestApp_VSCode(t *testing.T) {
 			wantErr: false,
 			wantURL: "vscode-insiders://github.codespaces/connect?name=monalisa-cli-cli-abcdef",
 		},
+		{
+			name: "open VS Code Web",
+			args: args{
+				codespaceName: "monalisa-cli-cli-abcdef",
+				useInsiders:   false,
+				useWeb:        true,
+			},
+			wantErr: false,
+			wantURL: "https://monalisa-cli-cli-abcdef.github.dev",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,7 +57,7 @@ func TestApp_VSCode(t *testing.T) {
 				browser:   b,
 				apiClient: testCodeApiMock(),
 			}
-			if err := a.VSCode(context.Background(), tt.args.codespaceName, tt.args.useInsiders); (err != nil) != tt.wantErr {
+			if err := a.VSCode(context.Background(), tt.args.codespaceName, tt.args.useInsiders, tt.args.useWeb); (err != nil) != tt.wantErr {
 				t.Errorf("App.VSCode() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			b.Verify(t, tt.wantURL)
@@ -57,7 +68,7 @@ func TestApp_VSCode(t *testing.T) {
 func TestPendingOperationDisallowsCode(t *testing.T) {
 	app := testingCodeApp()
 
-	if err := app.VSCode(context.Background(), "disabledCodespace", false); err != nil {
+	if err := app.VSCode(context.Background(), "disabledCodespace", false, false); err != nil {
 		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
@@ -75,6 +86,7 @@ func testCodeApiMock() *apiClientMock {
 	user := &api.User{Login: "monalisa"}
 	testingCodespace := &api.Codespace{
 		Name: "monalisa-cli-cli-abcdef",
+		WebUrl: "https://monalisa-cli-cli-abcdef.github.dev",
 	}
 	disabledCodespace := &api.Codespace{
 		Name:                           "disabledCodespace",


### PR DESCRIPTION
Fixes #4985

- Adds `--web` flag to open the codespace in vscode web. 
- updates `codespaces/api/api.go` `Codespace` type to include `WebUrl`  
